### PR TITLE
Fix version checking so 1.2.11 > 1.2.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ import subprocess
 
 from distutils.command.build_ext import build_ext
 from distutils import sysconfig
+from distutils.version import StrictVersion
 from setuptools import Extension, setup, find_packages
 
 # monkey patch import hook. Even though flake8 says it's not used, it is.
@@ -709,7 +710,7 @@ class pil_build_ext(build_ext):
             m = re.match(r'#define\s+ZLIB_VERSION\s+"([^"]*)"', line)
             if not m:
                 continue
-            if m.group(1) < "1.2.3":
+            if StrictVersion(m.group(1)) < StrictVersion("1.2.3"):
                 return m.group(1)
 
     # https://hg.python.org/users/barry/rev/7e8deab93d5a


### PR DESCRIPTION
Before:
```
--------------------------------------------------------------------
PIL SETUP SUMMARY
--------------------------------------------------------------------
version      Pillow 4.1.0.dev0
platform     win32 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 20:42:59)
             [MSC v.1500 32 bit (Intel)]
--------------------------------------------------------------------
--- JPEG support available
*** OPENJPEG (JPEG2000) support not available
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
*** LIBTIFF support not available
--- FREETYPE2 support available
--- LITTLECMS2 support available
--- WEBP support available
--- WEBPMUX support available
*** Warning: zlib 1.2.11
may contain a security vulnerability.
*** Consider upgrading to zlib 1.2.3 or newer.
*** See: http://www.kb.cert.org/vuls/id/238678
 http://www.kb.cert.org/vuls/id/680620
 http://www.gzip.org/zlib/advisory-2002-03-11.txt
--------------------------------------------------------------------
```
https://ci.appveyor.com/project/Python-pillow/pillow/build/4.1.pre.2039/job/v0o3uwr2ml6mtxqa#L1344

After:
```
--------------------------------------------------------------------
PIL SETUP SUMMARY
--------------------------------------------------------------------
version      Pillow 4.1.0.dev0
platform     win32 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 20:42:59)
             [MSC v.1500 32 bit (Intel)]
--------------------------------------------------------------------
--- JPEG support available
*** OPENJPEG (JPEG2000) support not available
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
*** LIBTIFF support not available
--- FREETYPE2 support available
--- LITTLECMS2 support available
--- WEBP support available
--- WEBPMUX support available
--------------------------------------------------------------------
```
https://ci.appveyor.com/project/hugovk/pillow/build/4.1.pre.232/job/wsfhfgf1krhq3bls#L1343