### PR TITLE
Small optimisation: move distance==0 comparison to outer loop

### DIFF
--- a/src/libImaging/Effects.c
+++ b/src/libImaging/Effects.c
@@ -131,11 +131,15 @@ ImagingEffectSpread(Imaging imIn, int distance)
     }
 
 #define SPREAD(type, image)\
-    for (y = 0; y < imOut->ysize; y++) {\
-        for (x = 0; x < imOut->xsize; x++) {\
-            if (distance == 0) {\
+    if (distance == 0) {\
+        for (y = 0; y < imOut->ysize; y++) {\
+            for (x = 0; x < imOut->xsize; x++) {\
                 imOut->image[y][x] = imIn->image[y][x];\
-            } else {\
+            }\
+        }\
+    } else {\
+        for (y = 0; y < imOut->ysize; y++) {\
+            for (x = 0; x < imOut->xsize; x++) {\
                 int xx = x + (rand() % distance) - distance/2;\
                 int yy = y + (rand() % distance) - distance/2;\
                 if (xx >= 0 && xx < imIn->xsize && yy >= 0 && yy < imIn->ysize) {\


### PR DESCRIPTION
Updates https://github.com/python-pillow/Pillow/pull/4908.

Check `distance==0` once per call, instead of once per pixel. Helps with larger images.

# Test

```python
from timeit import default_timer as timer
from PIL import Image

im = Image.new(mode="RGB", size=(100_000, 100_000))

start = timer()

im.effect_spread(distance=0)

end = timer()
print(end - start)  # Time in seconds, e.g. 5.38091952400282
```


# Original

```console
$ time p 1.py && time p 1.py
91.274287401
python3 1.py  33.99s user 69.12s system 79% cpu 2:10.15 total
106.27533985
python3 1.py  34.41s user 69.71s system 70% cpu 2:27.80 total
```

# New

```console
$ time p 1.py && time p 1.py
80.202568548
python3 1.py  32.81s user 64.05s system 83% cpu 1:55.59 total
81.148895619
python3 1.py  32.99s user 64.28s system 81% cpu 1:59.84 total
```


