### PR TITLE
Avoid passing NULL to PyDict_SetItemString

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3810,6 +3810,7 @@ static PyTypeObject PixelAccess_Type = {
 static PyObject *
 _get_stats(PyObject *self, PyObject *args) {
     PyObject *d;
+    PyObject *v;
     ImagingMemoryArena arena = &ImagingDefaultArena;
 
     if (!PyArg_ParseTuple(args, ":get_stats")) {
@@ -3820,29 +3821,29 @@ _get_stats(PyObject *self, PyObject *args) {
     if (!d) {
         return NULL;
     }
-    PyObject *new_count = PyLong_FromLong(arena->stats_new_count);
-    PyDict_SetItemString(d, "new_count", new_count);
-    Py_XDECREF(new_count);
+    v = PyLong_FromLong(arena->stats_new_count);
+    PyDict_SetItemString(d, "new_count", v ? v : Py_None);
+    Py_XDECREF(v);
 
-    PyObject *allocated_blocks = PyLong_FromLong(arena->stats_allocated_blocks);
-    PyDict_SetItemString(d, "allocated_blocks", allocated_blocks);
-    Py_XDECREF(allocated_blocks);
+    v = PyLong_FromLong(arena->stats_allocated_blocks);
+    PyDict_SetItemString(d, "allocated_blocks", v ? v : Py_None);
+    Py_XDECREF(v);
 
-    PyObject *reused_blocks = PyLong_FromLong(arena->stats_reused_blocks);
-    PyDict_SetItemString(d, "reused_blocks", reused_blocks);
-    Py_XDECREF(reused_blocks);
+    v = PyLong_FromLong(arena->stats_reused_blocks);
+    PyDict_SetItemString(d, "reused_blocks", v ? v : Py_None);
+    Py_XDECREF(v);
 
-    PyObject *reallocated_blocks = PyLong_FromLong(arena->stats_reallocated_blocks);
-    PyDict_SetItemString(d, "reallocated_blocks", reallocated_blocks);
-    Py_XDECREF(reallocated_blocks);
+    v = PyLong_FromLong(arena->stats_reallocated_blocks);
+    PyDict_SetItemString(d, "reallocated_blocks", v ? v : Py_None);
+    Py_XDECREF(v);
 
-    PyObject *freed_blocks = PyLong_FromLong(arena->stats_freed_blocks);
-    PyDict_SetItemString(d, "freed_blocks", freed_blocks);
-    Py_XDECREF(freed_blocks);
+    v = PyLong_FromLong(arena->stats_freed_blocks);
+    PyDict_SetItemString(d, "freed_blocks", v ? v : Py_None);
+    Py_XDECREF(v);
 
-    PyObject *blocks_cached = PyLong_FromLong(arena->blocks_cached);
-    PyDict_SetItemString(d, "blocks_cached", blocks_cached);
-    Py_XDECREF(blocks_cached);
+    v = PyLong_FromLong(arena->blocks_cached);
+    PyDict_SetItemString(d, "blocks_cached", v ? v : Py_None);
+    Py_XDECREF(v);
     return d;
 }
 
@@ -4211,31 +4212,33 @@ setup_module(PyObject *m) {
 #ifdef HAVE_LIBJPEG
     {
         extern const char *ImagingJpegVersion(void);
-        PyObject *jpeglib_version = PyUnicode_FromString(ImagingJpegVersion());
-        PyDict_SetItemString(d, "jpeglib_version", jpeglib_version);
-        Py_XDECREF(jpeglib_version);
+        PyObject *v = PyUnicode_FromString(ImagingJpegVersion());
+        PyDict_SetItemString(d, "jpeglib_version", v ? v : Py_None);
+        Py_XDECREF(v);
     }
 #endif
 
 #ifdef HAVE_OPENJPEG
     {
         extern const char *ImagingJpeg2KVersion(void);
-        PyObject *jp2klib_version = PyUnicode_FromString(ImagingJpeg2KVersion());
-        PyDict_SetItemString(d, "jp2klib_version", jp2klib_version);
-        Py_XDECREF(jp2klib_version);
+        PyObject *v = PyUnicode_FromString(ImagingJpeg2KVersion());
+        PyDict_SetItemString(d, "jp2klib_version", v ? v : Py_None);
+        Py_XDECREF(v);
     }
 #endif
 
     PyObject *have_libjpegturbo;
 #ifdef LIBJPEG_TURBO_VERSION
     have_libjpegturbo = Py_True;
+    {
 #define tostr1(a) #a
 #define tostr(a) tostr1(a)
-    PyObject *libjpeg_turbo_version = PyUnicode_FromString(tostr(LIBJPEG_TURBO_VERSION));
-    PyDict_SetItemString(d, "libjpeg_turbo_version", libjpeg_turbo_version);
-    Py_XDECREF(libjpeg_turbo_version);
+        PyObject *v = PyUnicode_FromString(tostr(LIBJPEG_TURBO_VERSION));
+        PyDict_SetItemString(d, "libjpeg_turbo_version", v ? v : Py_None);
+        Py_XDECREF(v);
 #undef tostr
 #undef tostr1
+    }
 #else
     have_libjpegturbo = Py_False;
 #endif
@@ -4247,9 +4250,9 @@ setup_module(PyObject *m) {
     have_libimagequant = Py_True;
     {
         extern const char *ImagingImageQuantVersion(void);
-        PyObject *imagequant_version = PyUnicode_FromString(ImagingImageQuantVersion());
-        PyDict_SetItemString(d, "imagequant_version", imagequant_version);
-        Py_XDECREF(imagequant_version);
+        PyObject *v = PyUnicode_FromString(ImagingImageQuantVersion());
+        PyDict_SetItemString(d, "imagequant_version", v ? v : Py_None);
+        Py_XDECREF(v);
     }
 #else
     have_libimagequant = Py_False;
@@ -4266,18 +4269,18 @@ setup_module(PyObject *m) {
     PyModule_AddIntConstant(m, "FIXED", Z_FIXED);
     {
         extern const char *ImagingZipVersion(void);
-        PyObject *zlibversion = PyUnicode_FromString(ImagingZipVersion());
-        PyDict_SetItemString(d, "zlib_version", zlibversion);
-        Py_XDECREF(zlibversion);
+        PyObject *v = PyUnicode_FromString(ImagingZipVersion());
+        PyDict_SetItemString(d, "zlib_version", v ? v : Py_None);
+        Py_XDECREF(v);
     }
 #endif
 
 #ifdef HAVE_LIBTIFF
     {
         extern const char *ImagingTiffVersion(void);
-        PyObject *libtiff_version = PyUnicode_FromString(ImagingTiffVersion());
-        PyDict_SetItemString(d, "libtiff_version", libtiff_version);
-        Py_XDECREF(libtiff_version);
+        PyObject *v = PyUnicode_FromString(ImagingTiffVersion());
+        PyDict_SetItemString(d, "libtiff_version", v ? v : Py_None);
+        Py_XDECREF(v);
 
         // Test for libtiff 4.0 or later, excluding libtiff 3.9.6 and 3.9.7
         PyObject *support_custom_tags;
@@ -4301,7 +4304,7 @@ setup_module(PyObject *m) {
     PyModule_AddObject(m, "HAVE_XCB", have_xcb);
 
     PyObject *pillow_version = PyUnicode_FromString(version);
-    PyDict_SetItemString(d, "PILLOW_VERSION", pillow_version);
+    PyDict_SetItemString(d, "PILLOW_VERSION", pillow_version ? pillow_version : Py_None);
     Py_XDECREF(pillow_version);
 
     return 0;

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1533,7 +1533,7 @@ setup_module(PyObject *m) {
     } else {
         v = PyUnicode_FromFormat("%d.%d", vn / 1000, (vn / 10) % 100);
     }
-    PyDict_SetItemString(d, "littlecms_version", v);
+    PyDict_SetItemString(d, "littlecms_version", v ? v : Py_None);
     Py_XDECREF(v);
 
     return 0;

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1130,15 +1130,15 @@ font_getvaraxes(FontObject *self) {
 
         list_axis = PyDict_New();
         PyObject *minimum = PyLong_FromLong(axis.minimum / 65536);
-        PyDict_SetItemString(list_axis, "minimum", minimum);
+        PyDict_SetItemString(list_axis, "minimum", minimum ? minimum : Py_None);
         Py_XDECREF(minimum);
 
         PyObject *def = PyLong_FromLong(axis.def / 65536);
-        PyDict_SetItemString(list_axis, "default", def);
+        PyDict_SetItemString(list_axis, "default", def ? def : Py_None);
         Py_XDECREF(def);
 
         PyObject *maximum = PyLong_FromLong(axis.maximum / 65536);
-        PyDict_SetItemString(list_axis, "maximum", maximum);
+        PyDict_SetItemString(list_axis, "maximum", maximum ? maximum : Py_None);
         Py_XDECREF(maximum);
 
         for (j = 0; j < name_count; j++) {
@@ -1149,7 +1149,7 @@ font_getvaraxes(FontObject *self) {
 
             if (name.name_id == axis.strid) {
                 axis_name = Py_BuildValue("y#", name.string, name.string_len);
-                PyDict_SetItemString(list_axis, "name", axis_name);
+                PyDict_SetItemString(list_axis, "name", axis_name ? axis_name : Py_None);
                 Py_XDECREF(axis_name);
                 break;
             }

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1365,7 +1365,7 @@ setup_module(PyObject *m) {
     FT_Library_Version(library, &major, &minor, &patch);
 
     v = PyUnicode_FromFormat("%d.%d.%d", major, minor, patch);
-    PyDict_SetItemString(d, "freetype2_version", v);
+    PyDict_SetItemString(d, "freetype2_version", v ? v : Py_None);
     Py_XDECREF(v);
 
 #ifdef HAVE_RAQM
@@ -1386,35 +1386,32 @@ setup_module(PyObject *m) {
     PyDict_SetItemString(d, "HAVE_HARFBUZZ", v);
     Py_DECREF(v);
     if (have_raqm) {
+        v = NULL;
 #ifdef RAQM_VERSION_MAJOR
         v = PyUnicode_FromString(raqm_version_string());
-#else
-        v = Py_None;
 #endif
-        PyDict_SetItemString(d, "raqm_version", v);
+        PyDict_SetItemString(d, "raqm_version", v ? v : Py_None);
         Py_XDECREF(v);
 
+        v = NULL;
 #ifdef FRIBIDI_MAJOR_VERSION
         {
             const char *a = strchr(fribidi_version_info, ')');
             const char *b = strchr(fribidi_version_info, '\n');
             if (a && b && a + 2 < b) {
                 v = PyUnicode_FromStringAndSize(a + 2, b - (a + 2));
-            } else {
-                v = Py_None;
             }
         }
-#else
-        v = Py_None;
 #endif
-        PyDict_SetItemString(d, "fribidi_version", v);
+        PyDict_SetItemString(d, "fribidi_version", v ? v : Py_None);
+        Py_XDECREF(v);
 
+        v = NULL;
 #ifdef HB_VERSION_STRING
         v = PyUnicode_FromString(hb_version_string());
-#else
-        v = Py_None;
 #endif
-        PyDict_SetItemString(d, "harfbuzz_version", v);
+        PyDict_SetItemString(d, "harfbuzz_version", v ? v : Py_None);
+        Py_XDECREF(v);
     }
 
     return 0;

--- a/src/_imagingmorph.c
+++ b/src/_imagingmorph.c
@@ -238,17 +238,6 @@ get_on_pixels(PyObject *self, PyObject *args) {
     return ret;
 }
 
-static int
-setup_module(PyObject *m) {
-    PyObject *d = PyModule_GetDict(m);
-
-    PyObject *version = PyUnicode_FromString("0.1");
-    PyDict_SetItemString(d, "__version", version);
-    Py_XDECREF(version);
-
-    return 0;
-}
-
 static PyMethodDef functions[] = {
     /* Functions */
     {"apply", (PyCFunction)apply, METH_VARARGS, NULL},
@@ -269,10 +258,6 @@ PyInit__imagingmorph(void) {
     };
 
     m = PyModule_Create(&module_def);
-
-    if (setup_module(m) < 0) {
-        return NULL;
-    }
 
     return m;
 }

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -962,9 +962,9 @@ setup_module(PyObject *m) {
     addAnimFlagToModule(m);
     addTransparencyFlagToModule(m);
 
-    PyObject *webpdecoder_version = PyUnicode_FromString(WebPDecoderVersion_str());
-    PyDict_SetItemString(d, "webpdecoder_version", webpdecoder_version);
-    Py_XDECREF(webpdecoder_version);
+    PyObject *v = PyUnicode_FromString(WebPDecoderVersion_str());
+    PyDict_SetItemString(d, "webpdecoder_version", v ? v : Py_None);
+    Py_XDECREF(v);
 
 #ifdef HAVE_WEBPANIM
     /* Ready object types */


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/pull/7003

Two suggestions:
* do not `Py_DECREF(Py_None)` here: https://github.com/python-pillow/Pillow/pull/7003/files#diff-a7e6dcef8b0ae21843d090666c67e89f073e658f1d532b503f56cabd255e001cR1395
* avoid passing `NULL` to `PyDict_SetItemString`

The `PyDict_SetItemString` function (indirectly) calls `assert(value)` here: https://github.com/python/cpython/blob/ef000eb3e2a8d0ecd51b6d44b390fefd820a61a6/Objects/dictobject.c#L1838

I would suggest replacing all `PyDict_SetItemString(..., value)` calls with `PyDict_SetItemString(..., value ? value : Py_None)`, with the exception of the unused private attribute `_imagingmorph.__version` which can be removed without deprecation.