### PR TITLE
Fix documentation link to PIL.ImageFont.Layout

### DIFF
--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -70,21 +70,20 @@ Methods
 Constants
 ---------
 
-.. data:: PIL.ImageFont.Layout.BASIC
+.. class:: Layout
 
-    Use basic text layout for TrueType font.
-    Advanced features such as text direction are not supported.
+    .. py:attribute:: BASIC
 
-.. data:: PIL.ImageFont.Layout.RAQM
+        Use basic text layout for TrueType font.
+        Advanced features such as text direction are not supported.
 
-    Use Raqm text layout for TrueType font.
-    Advanced features are supported.
+    .. py:attribute:: RAQM
 
-    Requires Raqm, you can check support using
-    :py:func:`PIL.features.check_feature` with ``feature="raqm"``.
+        Use Raqm text layout for TrueType font.
+        Advanced features are supported.
 
-Constants
----------
+        Requires Raqm, you can check support using
+        :py:func:`PIL.features.check_feature` with ``feature="raqm"``.
 
 .. data:: MAX_STRING_LENGTH
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -787,7 +787,7 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
                      This specifies the character set to use. It does not alter the
                      encoding of any text provided in subsequent operations.
     :param layout_engine: Which layout engine to use, if available:
-                     :data:`.ImageFont.Layout.BASIC` or :data:`.ImageFont.Layout.RAQM`.
+                     :attr:`.ImageFont.Layout.BASIC` or :attr:`.ImageFont.Layout.RAQM`.
                      If it is available, Raqm layout will be used by default.
                      Otherwise, basic layout will be used.
 


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/pull/7578

Looking at [the generated docs](https://pillow--7578.org.readthedocs.build/en/7578/reference/ImageFont.html#PIL.ImageFont.FreeTypeFont), I can see that the parameter type annotation `Layout` does not link to documentation for `ImageFont.Layout` because that class is not listed in the documentation.

Checking locally, I find that this commit fixes that.