### PR TITLE
Fix loading IPTC images and update test

### DIFF
--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -6,18 +6,21 @@ import pytest
 
 from PIL import Image, IptcImagePlugin
 
-from .helper import hopper
+from .helper import assert_image_equal, hopper
 
 TEST_FILE = "Tests/images/iptc.jpg"
 
 
 def test_open():
+    expected = Image.new("L", (1, 1), 0)
+
     f = BytesIO(
-        b"\x1c\x03<\x00\x02\x01\x00\x1c\x03x\x00\x01\x01\x1c"
-        b"\x03\x14\x00\x01\x01\x1c\x03\x1e\x00\x01\x01\x1c\x08\n\x00\x00"
+        b"\x1c\x03<\x00\x02\x01\x00\x1c\x03x\x00\x01\x01\x1c\x03\x14\x00\x01\x01"
+        b"\x1c\x03\x1e\x00\x01\x01\x1c\x08\n\x00\x01\x00"
     )
     with Image.open(f) as im:
         assert im.tile == [("iptc", (0, 0, 1, 1), 25, "raw")]
+        assert_image_equal(im, expected)
 
 
 def test_getiptcinfo_jpg_none():

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -12,7 +12,7 @@ TEST_FILE = "Tests/images/iptc.jpg"
 
 
 def test_open():
-    expected = Image.new("L", (1, 1), 0)
+    expected = Image.new("L", (1, 1))
 
     f = BytesIO(
         b"\x1c\x03<\x00\x02\x01\x00\x1c\x03x\x00\x01\x01\x1c\x03\x14\x00\x01\x01"


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7661

I added a byte to also test the `load` method, but found that, at least on Windows, this fails due to the unusual use of a temporary file, so I replaced it with `io.BytesIO`.

I also realigned the test bytes to avoid breaking in the middle of a dataset.