### PR TITLE
Fix GetWindowDpiAwarenessContext NULL check

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -359,9 +359,9 @@ PyImaging_GrabScreenWin32(PyObject *self, PyObject *args) {
     user32 = LoadLibraryA("User32.dll");
     SetThreadDpiAwarenessContext_function = (Func_SetThreadDpiAwarenessContext
     )GetProcAddress(user32, "SetThreadDpiAwarenessContext");
-    GetWindowDpiAwarenessContext_function = (Func_GetWindowDpiAwarenessContext
-    )GetProcAddress(user32, "GetWindowDpiAwarenessContext");
     if (SetThreadDpiAwarenessContext_function != NULL) {
+        GetWindowDpiAwarenessContext_function = (Func_GetWindowDpiAwarenessContext
+        )GetProcAddress(user32, "GetWindowDpiAwarenessContext");
         if (screens == -1 && GetWindowDpiAwarenessContext_function != NULL) {
             dpiAwareness =
                 GetWindowDpiAwarenessContext_function(wnd);

--- a/src/display.c
+++ b/src/display.c
@@ -363,11 +363,12 @@ PyImaging_GrabScreenWin32(PyObject *self, PyObject *args) {
         GetWindowDpiAwarenessContext_function = (Func_GetWindowDpiAwarenessContext
         )GetProcAddress(user32, "GetWindowDpiAwarenessContext");
         if (screens == -1 && GetWindowDpiAwarenessContext_function != NULL) {
-            dpiAwareness =
-                GetWindowDpiAwarenessContext_function(wnd);
+            dpiAwareness = GetWindowDpiAwarenessContext_function(wnd);
         }
         // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE = ((DPI_CONTEXT_HANDLE)-3)
-        dpiAwareness = SetThreadDpiAwarenessContext_function(dpiAwareness == NULL ? (HANDLE)-3 : dpiAwareness);
+        dpiAwareness = SetThreadDpiAwarenessContext_function(
+            dpiAwareness == NULL ? (HANDLE)-3 : dpiAwareness
+        );
     }
 
     if (screens == 1) {


### PR DESCRIPTION
Fix for my suggestion for [#8456](https://github.com/python-pillow/Pillow/pull/8516)

I also slightly simplified the code and removed the use of the `DPI_AWARENESS_CONTEXT` type - IIRC it was not available in VS2017.