### PR TITLE
Skip failing WMF records on 32-bit Windows

### DIFF
--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from io import BytesIO
 from pathlib import Path
 from typing import IO
@@ -43,7 +42,6 @@ def test_load_zero_inch() -> None:
             pass
 
 
-@pytest.mark.skipif(sys.maxsize <= 2**32, reason="Requires 64-bit system")
 def test_render() -> None:
     with open("Tests/images/drawing.emf", "rb") as fp:
         data = fp.read()

--- a/src/display.c
+++ b/src/display.c
@@ -716,7 +716,7 @@ PyImaging_EventLoopWin32(PyObject *self, PyObject *args) {
 
 #define GET32(p, o) ((DWORD *)(p + o))[0]
 
-int
+static int CALLBACK
 enhMetaFileProc(
     HDC hdc, HANDLETABLE *lpht, const ENHMETARECORD *lpmr, int nHandles, LPARAM data
 ) {
@@ -804,14 +804,7 @@ PyImaging_DrawWmf(PyObject *self, PyObject *args) {
     /* FIXME: make background transparent? configurable? */
     FillRect(dc, &rect, GetStockObject(WHITE_BRUSH));
 
-#ifdef _WIN64
     EnumEnhMetaFile(dc, meta, enhMetaFileProc, NULL, &rect);
-#else
-    if (!PlayEnhMetaFile(dc, meta, &rect)) {
-        PyErr_SetString(PyExc_OSError, "cannot render metafile");
-        goto error;
-    }
-#endif
 
     /* step 4: extract bits from bitmap */
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8506#discussion_r1890622272